### PR TITLE
fix(Whitelist): Lower request speed to not be blocked

### DIFF
--- a/Arbie/Actions/whitelist.py
+++ b/Arbie/Actions/whitelist.py
@@ -14,4 +14,6 @@ class Whitelist(Action):
     """
 
     async def on_next(self, data):
-        data.whitelist(await Coingecko().coins())
+        # 2 requests every 0.6 seconds is equal to 3,33 req/sec
+        # In total we need to do ~6000 request which will take 30 min
+        data.whitelist(await Coingecko(2, 0.6).coins())  # noqa: WPS432

--- a/Arbie/Services/coingecko.py
+++ b/Arbie/Services/coingecko.py
@@ -12,6 +12,10 @@ COINS_URL = urljoin(COINGECKO_URL, "api/v3/coins/list")
 
 
 class Coingecko(object):
+    def __init__(self, batch_size=5, timeout=0.6):
+        self.batch_size = batch_size
+        self.timeout = timeout
+
     async def coins(self):
         ids = await self.ids()
         if ids:
@@ -31,7 +35,7 @@ class Coingecko(object):
 
     async def _coin_urls(self, ids):
         urls = list(map(self._coin_url, ids))
-        return await async_map(self._get, urls, 10, 1)
+        return await async_map(self._get, urls, self.batch_size, self.timeout)
 
     async def _coin_ticker(self, coin_id):
         url = self._coin_url(coin_id)


### PR DESCRIPTION
Coingecko only allows 10 requests/seconds however when we are close
to those speeds we get blocked.