### PR TITLE
ci(PSR): Use latest master of PSR

### DIFF
--- a/.github/workflows/python_publish.yml
+++ b/.github/workflows/python_publish.yml
@@ -21,7 +21,7 @@ jobs:
         access-token: ${{ secrets.ACCESS_TOKEN }}
 
     - name: Python Semantic Release
-      uses: relekang/python-semantic-release@v7.12.0
+      uses: relekang/python-semantic-release@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         pypi_token: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Since PSR quickly addressed our issue https://github.com/relekang/python-semantic-release/issues/317
we can switch back to deploying using master